### PR TITLE
Fix get_auth_url usage in sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Requesting a token
     client = Smashrun(client_id='my_client_id',
                       redirect_uri='urn:ietf:wg:oauth:2.0:auto')
     auth_url = client.get_auth_url()
-    code = input("Go to '%s' and authorize this application. Paste the provided code here:" % auth_url)
+    code = input("Go to '%s' and authorize this application. Paste the provided code here:" % auth_url[0])
     client.fetch_token(code=code)
 
 


### PR DESCRIPTION
In README.rst, the formatted string `auth_url` is passed to input but `auth_url` is assigned a tuple from `client.get_auth_url()`, the second value which is a token. Alternatively, you could assign `auth_url` with the first tuple value from `client.get_auth_url()`, which ever style you prefer. Either way, the example currently won't function as-is.
