### PR TITLE
Fix timestamp creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean
 
 clean:
-	git clean -X
+	git clean -fdX
 
 test:
 	tox

--- a/smashrun/client.py
+++ b/smashrun/client.py
@@ -1,8 +1,11 @@
 """ This module contains main user-facing Smashrun interface.
 
 """
+from __future__ import division
+
 import json
-import time
+import datetime
+
 
 from requests_oauthlib import OAuth2Session
 
@@ -184,8 +187,18 @@ class Smashrun(object):
 
 
 def to_timestamp(dt):
-    """Convert a datetime object to a unix timestamp (UTC)."""
-    return int(time.mktime(dt.timetuple()))
+    """Convert a datetime object to a unix timestamp.
+
+    Note that unlike a typical unix timestamp, this is seconds since 1970
+    *local time*, not UTC.
+    """
+    return int(total_seconds(dt.replace(tzinfo=None) - datetime.datetime(1970, 1, 1)))
+
+
+def total_seconds(delta):
+    if hasattr(delta, 'total_seconds'):
+        return delta.total_seconds()
+    return (delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 10**6) / 10**6
 
 
 def is_aware(d):

--- a/smashrun/client.py
+++ b/smashrun/client.py
@@ -76,7 +76,9 @@ class Smashrun(object):
         """Iterate over all activities, from newest to oldest.
 
         :param count: The number of results to retrieve per page.
-        :param since: Return only activities since this date.
+        :param since: Return only activities since this date. Can be either
+                      a timestamp or a datetime object.
+
         :param style: The type of records to return. May be one of
                       'summary', 'brief', or 'ids'.
 
@@ -191,7 +193,12 @@ def to_timestamp(dt):
 
     Note that unlike a typical unix timestamp, this is seconds since 1970
     *local time*, not UTC.
+
+    If the passed in object is already a timestamp, then that value is
+    simply returned unmodified.
     """
+    if isinstance(dt, int):
+        return dt
     return int(total_seconds(dt.replace(tzinfo=None) - datetime.datetime(1970, 1, 1)))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34
+envlist = py26, py27, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
The smashrun API is a bit weird in that the timestamps that it
accepts in the fromDate query parameter are expected to be local time,
not UTC.

Now, the timestamp we generate is just `<current time> - <jan 1, 1970>` and is
completely oblivious of time zones.

This fixes #6

Note that when they add `fromDateUTC` we should switch to that since it
makes more sense.

I also made it so that `get_activities` will accept a timestamp directly instead of requiring a `datetime` object, which i thought might be helpful if there is any more weird time behavior
that my conversion doesn't handle.