### PR TITLE
Added APIs for new activity PUT/DELETE methods

### DIFF
--- a/smashrun/client.py
+++ b/smashrun/client.py
@@ -194,6 +194,18 @@ class Smashrun(object):
         r.raise_for_status()
         return r
 
+    def delete_activity(self, id_num):
+        """Delete an activity (run).
+
+        :param id_num: The activity ID to delete
+
+
+        """
+        url = self._build_url('my', 'activities', id_num)
+        r = self.session.delete(url)
+        r.raise_for_status()
+        return r
+
     def _iter(self, url, count, cls=None, **kwargs):
         page = 0
         while True:

--- a/smashrun/client.py
+++ b/smashrun/client.py
@@ -194,6 +194,21 @@ class Smashrun(object):
         r.raise_for_status()
         return r
 
+    def update_activity(self, id_num, data):
+        """Update an existing activity (run).
+
+        :param id_num: The activity ID to update
+        :param data: The data representing the activity you want to upload.
+                     May be either JSON, GPX, or TCX.
+
+        """
+        url = self._build_url('my', 'activities')
+        if isinstance(data, dict):
+            data = json.dumps(data)
+        r = self.session.put(url, data=data)
+        r.raise_for_status()
+        return r
+
     def delete_activity(self, id_num):
         """Delete an activity (run).
 


### PR DESCRIPTION
The Smashrun team updated their API this weekend to add put and delete methods. Here's a patch to add API to this library to enable them.

Reference thread: http://discuss.smashrun.com/t/updating-runs-via-api/103/7

nall.