### PR TITLE
Fix issues with create_weight

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,12 @@ Requesting a token
 .. code-block:: python
 
     # use urn:ietf:wg:oauth:2.0:oob for applications that aren't a web app
-    client = Smashrun(client_id='my_client_id',
+    client = Smashrun(client_id='my_client_id',client_secret='my_secret',
                       redirect_uri='urn:ietf:wg:oauth:2.0:auto')
     auth_url = client.get_auth_url()
     code = raw_input("Go to '%s' and authorize this application. Paste the provided code here:" % auth_url[0])
-    client.fetch_token(code=code)
+    response = client.fetch_token(code=code)
+    print(response['refresh_token'])
 
 
 **NOTE:** The example above assumes that you are running Python 2.x. If You are using Python 3.x you can replace

--- a/smashrun/client.py
+++ b/smashrun/client.py
@@ -170,13 +170,14 @@ class Smashrun(object):
                      specified, the current date will be used.
 
         """
-        if not date.is_aware():
-            raise ValueError("provided date is not timezone aware")
         url = self._build_url('my', 'body', 'weight')
         data = {'weightInKilograms': weight}
         if date:
+            if not date.is_aware():
+                raise ValueError("provided date is not timezone aware")
             data.update(date=date.isoformat())
-        r = self.session.post(url, data=json.dumps(data))
+        headers = {'Content-Type': 'application/json; charset=utf8'}
+        r = self.session.post(url, data=json.dumps(data), headers=headers)
         r.raise_for_status()
         return r
 


### PR DESCRIPTION
This PR fixes 3 issues

1. create_weight post requests were not accepted resulting in the following error

        requests.exceptions.HTTPError: 415 Client Error: Unsupported Media Type for url: https://api.smashrun.com/v1/my/body/weight
    this issue was fixed by adding a Content-Type header to the request

2. create_weight did not accept an empty date argument (although accepted by Smashrun API) as the ```is_aware()``` function was tested on the NoneType resulting in

        AttributeError: 'NoneType' object has no attribute 'is_aware'
    the issue was fixed by moving this check inside ```if date:```

3. the README suggests not using ```client_secret``` in authorizing the application, which results in an authorization code, but unable to obtain the response (including refresh token) in step 2, giving the following error:

        oauthlib.oauth2.rfc6749.errors.InvalidClientError: (invalid_client) Could not authenticate with specified client_id and client_secret
    the README example has been adapted to include client_secret and shows how to obtain refresh code from the response.